### PR TITLE
Cleanup styles and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:6a05bea7e6e11a7c666daac9b4ab7580f0185f920f9a9af462183cfba53145b0"
+content_hash = "sha256:fd9ab7ed4ba72966f75461da953ff982e35705dacb652d5f56b41ed3693d6cab"
 
 [[package]]
 name = "boto3"
@@ -33,6 +33,7 @@ dependencies = [
     "jmespath<2.0.0,>=0.7.1",
     "python-dateutil<3.0.0,>=2.1",
     "urllib3!=2.2.0,<3,>=1.25.4; python_version >= \"3.10\"",
+    "urllib3<1.27,>=1.25.4; python_version < \"3.10\"",
 ]
 files = [
     {file = "botocore-1.34.81-py3-none-any.whl", hash = "sha256:85f6fd7c5715eeef7a236c50947de00f57d72e7439daed1125491014b70fab01"},
@@ -52,24 +53,15 @@ files = [
 ]
 
 [[package]]
-name = "coverage"
-version = "7.4.4"
-requires_python = ">=3.8"
-summary = "Code coverage measurement for Python"
+name = "exceptiongroup"
+version = "1.2.0"
+requires_python = ">=3.7"
+summary = "Backport of PEP 654 (exception groups)"
 groups = ["dev"]
+marker = "python_version < \"3.11\""
 files = [
-    {file = "coverage-7.4.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:201bef2eea65e0e9c56343115ba3814e896afe6d36ffd37bab783261db430f76"},
-    {file = "coverage-7.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41c9c5f3de16b903b610d09650e5e27adbfa7f500302718c9ffd1c12cf9d6818"},
-    {file = "coverage-7.4.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d898fe162d26929b5960e4e138651f7427048e72c853607f2b200909794ed978"},
-    {file = "coverage-7.4.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ea79bb50e805cd6ac058dfa3b5c8f6c040cb87fe83de10845857f5535d1db70"},
-    {file = "coverage-7.4.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce4b94265ca988c3f8e479e741693d143026632672e3ff924f25fab50518dd51"},
-    {file = "coverage-7.4.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:00838a35b882694afda09f85e469c96367daa3f3f2b097d846a7216993d37f4c"},
-    {file = "coverage-7.4.4-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:fdfafb32984684eb03c2d83e1e51f64f0906b11e64482df3c5db936ce3839d48"},
-    {file = "coverage-7.4.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:69eb372f7e2ece89f14751fbcbe470295d73ed41ecd37ca36ed2eb47512a6ab9"},
-    {file = "coverage-7.4.4-cp312-cp312-win32.whl", hash = "sha256:137eb07173141545e07403cca94ab625cc1cc6bc4c1e97b6e3846270e7e1fea0"},
-    {file = "coverage-7.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:d71eec7d83298f1af3326ce0ff1d0ea83c7cb98f72b577097f9083b20bdaf05e"},
-    {file = "coverage-7.4.4-pp38.pp39.pp310-none-any.whl", hash = "sha256:b2c5edc4ac10a7ef6605a966c58929ec6c1bd0917fb8c15cb3363f65aa40e677"},
-    {file = "coverage-7.4.4.tar.gz", hash = "sha256:c901df83d097649e257e803be22592aedfd5182f07b3cc87d640bbb9afd50f49"},
+    {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
+    {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
 ]
 
 [[package]]
@@ -102,6 +94,7 @@ summary = "Optional static typing for Python"
 groups = ["dev"]
 dependencies = [
     "mypy-extensions>=1.0.0",
+    "tomli>=1.1.0; python_version < \"3.11\"",
     "typing-extensions>=4.1.0",
 ]
 files = [
@@ -170,22 +163,43 @@ files = [
 
 [[package]]
 name = "pyarrow"
-version = "15.0.2"
+version = "16.0.0"
 requires_python = ">=3.8"
 summary = "Python library for Apache Arrow"
 groups = ["default"]
 dependencies = [
-    "numpy<2,>=1.16.6",
+    "numpy>=1.16.6",
 ]
 files = [
-    {file = "pyarrow-15.0.2-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:25335e6f1f07fdaa026a61c758ee7d19ce824a866b27bba744348fa73bb5a440"},
-    {file = "pyarrow-15.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:90f19e976d9c3d8e73c80be84ddbe2f830b6304e4c576349d9360e335cd627fc"},
-    {file = "pyarrow-15.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a22366249bf5fd40ddacc4f03cd3160f2d7c247692945afb1899bab8a140ddfb"},
-    {file = "pyarrow-15.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2a335198f886b07e4b5ea16d08ee06557e07db54a8400cc0d03c7f6a22f785f"},
-    {file = "pyarrow-15.0.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3e6d459c0c22f0b9c810a3917a1de3ee704b021a5fb8b3bacf968eece6df098f"},
-    {file = "pyarrow-15.0.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:033b7cad32198754d93465dcfb71d0ba7cb7cd5c9afd7052cab7214676eec38b"},
-    {file = "pyarrow-15.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:29850d050379d6e8b5a693098f4de7fd6a2bea4365bfd073d7c57c57b95041ee"},
-    {file = "pyarrow-15.0.2.tar.gz", hash = "sha256:9c9bc803cb3b7bfacc1e96ffbfd923601065d9d3f911179d81e72d99fd74a3d9"},
+    {file = "pyarrow-16.0.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:22a1fdb1254e5095d629e29cd1ea98ed04b4bbfd8e42cc670a6b639ccc208b60"},
+    {file = "pyarrow-16.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:574a00260a4ed9d118a14770edbd440b848fcae5a3024128be9d0274dbcaf858"},
+    {file = "pyarrow-16.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0815d0ddb733b8c1b53a05827a91f1b8bde6240f3b20bf9ba5d650eb9b89cdf"},
+    {file = "pyarrow-16.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df0080339387b5d30de31e0a149c0c11a827a10c82f0c67d9afae3981d1aabb7"},
+    {file = "pyarrow-16.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:edf38cce0bf0dcf726e074159c60516447e4474904c0033f018c1f33d7dac6c5"},
+    {file = "pyarrow-16.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:91d28f9a40f1264eab2af7905a4d95320ac2f287891e9c8b0035f264fe3c3a4b"},
+    {file = "pyarrow-16.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:99af421ee451a78884d7faea23816c429e263bd3618b22d38e7992c9ce2a7ad9"},
+    {file = "pyarrow-16.0.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:d22d0941e6c7bafddf5f4c0662e46f2075850f1c044bf1a03150dd9e189427ce"},
+    {file = "pyarrow-16.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:266ddb7e823f03733c15adc8b5078db2df6980f9aa93d6bb57ece615df4e0ba7"},
+    {file = "pyarrow-16.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cc23090224b6594f5a92d26ad47465af47c1d9c079dd4a0061ae39551889efe"},
+    {file = "pyarrow-16.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56850a0afe9ef37249d5387355449c0f94d12ff7994af88f16803a26d38f2016"},
+    {file = "pyarrow-16.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:705db70d3e2293c2f6f8e84874b5b775f690465798f66e94bb2c07bab0a6bb55"},
+    {file = "pyarrow-16.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:5448564754c154997bc09e95a44b81b9e31ae918a86c0fcb35c4aa4922756f55"},
+    {file = "pyarrow-16.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:729f7b262aa620c9df8b9967db96c1575e4cfc8c25d078a06968e527b8d6ec05"},
+    {file = "pyarrow-16.0.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:fb8065dbc0d051bf2ae2453af0484d99a43135cadabacf0af588a3be81fbbb9b"},
+    {file = "pyarrow-16.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:20ce707d9aa390593ea93218b19d0eadab56390311cb87aad32c9a869b0e958c"},
+    {file = "pyarrow-16.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5823275c8addbbb50cd4e6a6839952682a33255b447277e37a6f518d6972f4e1"},
+    {file = "pyarrow-16.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ab8b9050752b16a8b53fcd9853bf07d8daf19093533e990085168f40c64d978"},
+    {file = "pyarrow-16.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:42e56557bc7c5c10d3e42c3b32f6cff649a29d637e8f4e8b311d334cc4326730"},
+    {file = "pyarrow-16.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2a7abdee4a4a7cfa239e2e8d721224c4b34ffe69a0ca7981354fe03c1328789b"},
+    {file = "pyarrow-16.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:ef2f309b68396bcc5a354106741d333494d6a0d3e1951271849787109f0229a6"},
+    {file = "pyarrow-16.0.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:b93c9a50b965ee0bf4fef65e53b758a7e8dcc0c2d86cebcc037aaaf1b306ecc0"},
+    {file = "pyarrow-16.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d831690844706e374c455fba2fb8cfcb7b797bfe53ceda4b54334316e1ac4fa4"},
+    {file = "pyarrow-16.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35692ce8ad0b8c666aa60f83950957096d92f2a9d8d7deda93fb835e6053307e"},
+    {file = "pyarrow-16.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9dd3151d098e56f16a8389c1247137f9e4c22720b01c6f3aa6dec29a99b74d80"},
+    {file = "pyarrow-16.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:bd40467bdb3cbaf2044ed7a6f7f251c8f941c8b31275aaaf88e746c4f3ca4a7a"},
+    {file = "pyarrow-16.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:00a1dcb22ad4ceb8af87f7bd30cc3354788776c417f493089e0a0af981bc8d80"},
+    {file = "pyarrow-16.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:fda9a7cebd1b1d46c97b511f60f73a5b766a6de4c5236f144f41a5d5afec1f35"},
+    {file = "pyarrow-16.0.0.tar.gz", hash = "sha256:59bb1f1edbbf4114c72415f039f1359f1a57d166a331c3229788ccbfbb31689a"},
 ]
 
 [[package]]
@@ -196,9 +210,11 @@ summary = "pytest: simple powerful testing with Python"
 groups = ["dev"]
 dependencies = [
     "colorama; sys_platform == \"win32\"",
+    "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
     "iniconfig",
     "packaging",
     "pluggy<2.0,>=1.4",
+    "tomli>=1; python_version < \"3.11\"",
 ]
 files = [
     {file = "pytest-8.1.1-py3-none-any.whl", hash = "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7"},
@@ -285,6 +301,18 @@ files = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+requires_python = ">=3.7"
+summary = "A lil' TOML parser"
+groups = ["dev"]
+marker = "python_version < \"3.11\""
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.11.0"
 requires_python = ">=3.8"
@@ -297,12 +325,11 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.1"
-requires_python = ">=3.8"
+version = "1.26.18"
+requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
 groups = ["default"]
-marker = "python_version >= \"3.10\""
 files = [
-    {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
-    {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
+    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
+    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 
 dependencies = [
     'boto3',
-    'pyarrow',
+    "pyarrow>=16.0.0",
 ]
 authors = [
     {name = "Becky Sweger", email = "rsweger@umass.edu"},
@@ -20,7 +20,6 @@ authors = [
 
 [project.optional-dependencies]
 dev = [
-    'coverage',
     'mypy',
     'pytest',
     'pytest-mock',
@@ -34,10 +33,6 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 line-length = 120
 lint.extend-select = ['I']
-
-[tool.ruff.format]
-quote-style = 'single'
-
 
 [tool.pdm]
 distribution = true

--- a/src/hubverse_transform/model_output.py
+++ b/src/hubverse_transform/model_output.py
@@ -9,7 +9,7 @@ from pyarrow import csv, fs
 # Log to stdout
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
-formatter = logging.Formatter('%(asctime)s -  %(levelname)s - %(name)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+formatter = logging.Formatter("%(asctime)s -  %(levelname)s - %(name)s - %(message)s", datefmt="%m/%d/%Y %I:%M:%S %p")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
@@ -31,24 +31,24 @@ class ModelOutputHandler:
         self.file_type = path.suffix
 
         # TODO: Add other input file types as needed
-        if self.file_type not in ['.csv', '.parquet']:
-            raise NotImplementedError(f'Unsupported file type: {path.suffix}')
+        if self.file_type not in [".csv", ".parquet"]:
+            raise NotImplementedError(f"Unsupported file type: {path.suffix}")
 
         # Parse model-output file name into individual parts
         # (round_id, team, model)
         file_parts = self.parse_file(self.file_name)
-        self.round_id = file_parts['round_id']
-        self.team = file_parts['team']
-        self.model = file_parts['model']
+        self.round_id = file_parts["round_id"]
+        self.team = file_parts["team"]
+        self.model = file_parts["model"]
 
     def __repr__(self):
         return f"ModelOutputHandler('{self.fs_input.type_name}', '{self.input_file}', '{self.output_path}')"
 
     def __str__(self):
-        return f'Handle model-output data transforms for {self.input_file}.'
+        return f"Handle model-output data transforms for {self.input_file}."
 
     @classmethod
-    def from_s3(cls, bucket_name: str, s3_key: str, origin_prefix: str = 'raw') -> 'ModelOutputHandler':
+    def from_s3(cls, bucket_name: str, s3_key: str, origin_prefix: str = "raw") -> "ModelOutputHandler":
         """Instantiate ModelOutputHandler for file on AWS S3."""
 
         # ModelOutputHandler is designed to operate on original versions of model-output
@@ -57,13 +57,13 @@ class ModelOutputHandler:
         # model-outputs.
         path = pathlib.Path(s3_key)
         if path.parts[0] != origin_prefix:
-            raise ValueError(f'Model output path {s3_key} does not begin with {origin_prefix}.')
+            raise ValueError(f"Model output path {s3_key} does not begin with {origin_prefix}.")
 
-        s3_input_uri = f's3://{bucket_name}/{s3_key}'
+        s3_input_uri = f"s3://{bucket_name}/{s3_key}"
 
         # Destination path = origin path w/o the origin prefix
         destination_path = str(path.relative_to(origin_prefix).parent)
-        s3_output_uri = f's3://{bucket_name}/{destination_path}'
+        s3_output_uri = f"s3://{bucket_name}/{destination_path}"
 
         return cls(s3_input_uri, s3_output_uri)
 
@@ -74,34 +74,34 @@ class ModelOutputHandler:
         # Code below assumes [round_id likely yyyy-mm-dd]-[team]-[model] AND
         # that there are no hyphens in team or model names
         # https://github.com/orgs/Infectious-Disease-Modeling-Hubs/discussions/10
-        file_name_split = file_name.rsplit('-', 2)
+        file_name_split = file_name.rsplit("-", 2)
 
         if (
-            file_name.count('-') > 4
+            file_name.count("-") > 4
             or len(file_name_split) != 3
-            or not re.match(r'^\d{4}-\d{2}-\d{2}$', file_name_split[0])
+            or not re.match(r"^\d{4}-\d{2}-\d{2}$", file_name_split[0])
         ):
-            raise ValueError(f'File name {file_name} not in expected model-output format: yyyy-mm-dd-team-model.')
+            raise ValueError(f"File name {file_name} not in expected model-output format: yyyy-mm-dd-team-model.")
 
         file_parts = {}
-        file_parts['round_id'] = file_name_split[0]
-        file_parts['team'] = file_name_split[1]
-        file_parts['model'] = file_name_split[2]
+        file_parts["round_id"] = file_name_split[0]
+        file_parts["team"] = file_name_split[1]
+        file_parts["model"] = file_name_split[2]
 
         # TODO: why so many logs?
-        logger.info(f'Parsed model-output filename: {file_parts}')
+        logger.info(f"Parsed model-output filename: {file_parts}")
         return file_parts
 
     def read_file(self) -> pa.table:
         """Read model-output file into PyArrow table."""
 
-        logger.info(f'Reading file: {self.input_file}')
+        logger.info(f"Reading file: {self.input_file}")
 
-        if self.file_type == '.csv':
+        if self.file_type == ".csv":
             model_output_file = self.fs_input.open_input_stream(self.input_file)
             # normalize incoming missing data values to null, regardless of data type
             options = csv.ConvertOptions(
-                null_values=['na', 'NA', '', ' ', 'null', 'Null', 'NaN', 'nan'], strings_can_be_null=True
+                null_values=["na", "NA", "", " ", "null", "Null", "NaN", "nan"], strings_can_be_null=True
             )
             model_output_table = csv.read_csv(model_output_file, convert_options=options)
         else:
@@ -116,16 +116,16 @@ class ModelOutputHandler:
         """Add model-output metadata columns to PyArrow table."""
 
         num_rows = model_output_table.num_rows
-        logger.info(f'Adding columns to table with {num_rows} rows')
+        logger.info(f"Adding columns to table with {num_rows} rows")
 
         # Create a dictionary of the existing columns
         existing_columns = {name: model_output_table[name] for name in model_output_table.column_names}
 
         # Create arrays that we'll use to append columns to the table
         new_columns = {
-            'round_id': pa.array([self.round_id for i in range(0, num_rows)]),
-            'team_abbr': pa.array([self.team for i in range(0, num_rows)]),
-            'model_abbr': pa.array([self.model for i in range(0, num_rows)]),
+            "round_id": pa.array([self.round_id for i in range(0, num_rows)]),
+            "team_abbr": pa.array([self.team for i in range(0, num_rows)]),
+            "model_abbr": pa.array([self.model for i in range(0, num_rows)]),
         }
 
         # Merge the new columns with the existing columns
@@ -137,12 +137,12 @@ class ModelOutputHandler:
     def write_parquet(self, updated_model_output_table: pa.table) -> str:
         """Write transformed model-output table to parquet file."""
 
-        transformed_file_path = f'{self.output_path}/{self.file_name}.parquet'
+        transformed_file_path = f"{self.output_path}/{self.file_name}.parquet"
 
         with self.fs_output.open_output_stream(transformed_file_path) as parquet_file:
             pq.write_table(updated_model_output_table, parquet_file)
 
-        logger.info(f'Finished writing parquet file: {transformed_file_path}')
+        logger.info(f"Finished writing parquet file: {transformed_file_path}")
 
         return transformed_file_path
 

--- a/test/integration/test_model_output_integration.py
+++ b/test/integration/test_model_output_integration.py
@@ -11,14 +11,14 @@ def test_file_path() -> pathlib.Path:
     """
     Return path to the integration test files.
     """
-    test_file_path = pathlib.Path(__file__).parent.joinpath('data')
+    test_file_path = pathlib.Path(__file__).parent.joinpath("data")
     return test_file_path
 
 
 def test_missing_model_output_id_numeric(tmpdir, test_file_path):
     """Test behavior of model_output_id columns when there are a mix of numeric and missing output_type_ids."""
-    output_dir = str(tmpdir.mkdir('model-output'))
-    file_path = test_file_path.joinpath('2024-07-07-teamabc-output_type_ids_numeric.csv')
+    output_dir = str(tmpdir.mkdir("model-output"))
+    file_path = test_file_path.joinpath("2024-07-07-teamabc-output_type_ids_numeric.csv")
     mo = ModelOutputHandler(file_path, output_dir)
     output_uri = mo.transform_model_output()
 
@@ -26,15 +26,15 @@ def test_missing_model_output_id_numeric(tmpdir, test_file_path):
     transformed_output = parquet.read_table(output_uri)
 
     # missing data values (e.g., NA) in a numeric column should be normalized to null
-    expr = pc.field('output_type_id').is_null()
+    expr = pc.field("output_type_id").is_null()
     null_output_type_rows = transformed_output.filter(expr)
     assert len(null_output_type_rows) == 2
 
 
 def test_missing_model_output_id_mixture(tmpdir, test_file_path):
     """Test behavior of model_output_id columns when there are a mix of numeric, string, and missing output_type_ids."""
-    output_dir = str(tmpdir.mkdir('model-output'))
-    file_path = test_file_path.joinpath('2024-07-07-teamabc-output_type_ids_mixed.csv')
+    output_dir = str(tmpdir.mkdir("model-output"))
+    file_path = test_file_path.joinpath("2024-07-07-teamabc-output_type_ids_mixed.csv")
     mo = ModelOutputHandler(file_path, output_dir)
     output_uri = mo.transform_model_output()
 
@@ -42,6 +42,6 @@ def test_missing_model_output_id_mixture(tmpdir, test_file_path):
     transformed_output = parquet.read_table(output_uri)
 
     # missing data values (e.g., NA) in a string column should be transformed to null
-    expr = pc.field('output_type_id').is_null()
+    expr = pc.field("output_type_id").is_null()
     null_output_type_rows = transformed_output.filter(expr)
     assert len(null_output_type_rows) == 8

--- a/test/unit/test_model_output.py
+++ b/test/unit/test_model_output.py
@@ -17,8 +17,8 @@ def model_output_table() -> pa.Table:
     """
     return pa.table(
         {
-            'location': ['earth', 'vulcan', 'seti alpha'],
-            'value': [11.11, 22.22, 33.33],
+            "location": ["earth", "vulcan", "seti alpha"],
+            "value": [11.11, 22.22, 33.33],
         }
     )
 
@@ -31,19 +31,19 @@ def model_output_data() -> list[dict[str, Any]]:
     """
 
     model_output_fieldnames = [
-        'reference_date',
-        'location',
-        'horizon',
-        'target',
-        'output_type',
-        'output_type_id',
-        'value',
+        "reference_date",
+        "location",
+        "horizon",
+        "target",
+        "output_type",
+        "output_type_id",
+        "value",
     ]
     model_output_list = [
-        ['2420-01-01', 'US', '1 light year', 'hospitalizations', 'quantile', 0.5, 62],
-        ['2420-01-01', 'US', '1 light year', 'hospitalizations', 'quantile', 0.75, 50.1],
-        ['2420-01-01', '03', 3, 'hospitalizations', 'mean', None, 33],
-        ['1999-12-31', 'US', 'last month', 'hospitalizations', 'pmf', 'large_increase', 2.597827508665773e-9],
+        ["2420-01-01", "US", "1 light year", "hospitalizations", "quantile", 0.5, 62],
+        ["2420-01-01", "US", "1 light year", "hospitalizations", "quantile", 0.75, 50.1],
+        ["2420-01-01", "03", 3, "hospitalizations", "mean", None, 33],
+        ["1999-12-31", "US", "last month", "hospitalizations", "pmf", "large_increase", 2.597827508665773e-9],
     ]
 
     model_output_dict_list = [
@@ -58,13 +58,13 @@ def test_csv_file(tmpdir, model_output_data) -> str:
     """
     Write a temporary csv file and return the URI for use in tests.
     """
-    test_file_dir = Path(tmpdir.mkdir('raw_csv'))
-    test_file_name = '2420-01-01-janeswayaddition-voyager1.csv'
+    test_file_dir = Path(tmpdir.mkdir("raw_csv"))
+    test_file_name = "2420-01-01-janeswayaddition-voyager1.csv"
     test_file_path = str(test_file_dir.joinpath(test_file_name))
 
     fieldnames = model_output_data[0].keys()
 
-    with open(test_file_path, 'w', newline='') as test_csv_file:
+    with open(test_file_path, "w", newline="") as test_csv_file:
         writer = csv.DictWriter(test_csv_file, fieldnames=fieldnames)
         writer.writeheader()
         for row in model_output_data:
@@ -78,8 +78,8 @@ def test_parquet_file(tmpdir, test_csv_file) -> str:
     """
     Write a temporary parquet file and return the URI for use in tests.
     """
-    test_file_dir = Path(tmpdir.mkdir('raw_parquet'))
-    test_file_name = '2420-01-01-janeswayaddition-voyager1.parquet'
+    test_file_dir = Path(tmpdir.mkdir("raw_parquet"))
+    test_file_name = "2420-01-01-janeswayaddition-voyager1.parquet"
     test_file_path = str(test_file_dir.joinpath(test_file_name))
     local = fs.LocalFileSystem()
 
@@ -92,156 +92,156 @@ def test_parquet_file(tmpdir, test_csv_file) -> str:
 
 
 def test_new_instance():
-    input_uri = 'mock:bucket123/raw/prefix1/prefix2/2420-01-01-team_one-model.csv'
-    output_uri = 'mock:bucket123/prefix1/prefix2'
+    input_uri = "mock:bucket123/raw/prefix1/prefix2/2420-01-01-team_one-model.csv"
+    output_uri = "mock:bucket123/prefix1/prefix2"
     mo = ModelOutputHandler(input_uri, output_uri)
-    assert mo.input_file == 'bucket123/raw/prefix1/prefix2/2420-01-01-team_one-model.csv'
-    assert mo.output_path == 'bucket123/prefix1/prefix2'
-    assert mo.file_name == '2420-01-01-team_one-model'
-    assert mo.file_type == '.csv'
-    assert mo.round_id == '2420-01-01'
-    assert mo.team == 'team_one'
-    assert mo.model == 'model'
+    assert mo.input_file == "bucket123/raw/prefix1/prefix2/2420-01-01-team_one-model.csv"
+    assert mo.output_path == "bucket123/prefix1/prefix2"
+    assert mo.file_name == "2420-01-01-team_one-model"
+    assert mo.file_type == ".csv"
+    assert mo.round_id == "2420-01-01"
+    assert mo.team == "team_one"
+    assert mo.model == "model"
 
 
 @pytest.mark.parametrize(
-    's3_key, expected_input_uri, expected_output_uri',
+    "s3_key, expected_input_uri, expected_output_uri",
     [
         (
-            'raw/prefix1/prefix2/2420-01-01-team-model.csv',
-            's3://bucket123/raw/prefix1/prefix2/2420-01-01-team-model.csv',
-            's3://bucket123/prefix1/prefix2',
+            "raw/prefix1/prefix2/2420-01-01-team-model.csv",
+            "s3://bucket123/raw/prefix1/prefix2/2420-01-01-team-model.csv",
+            "s3://bucket123/prefix1/prefix2",
         ),
         (
-            'raw/model-output/prefix1/prefix2/2420-01-01-team-model.parquet',
-            's3://bucket123/raw/model-output/prefix1/prefix2/2420-01-01-team-model.parquet',
-            's3://bucket123/model-output/prefix1/prefix2',
+            "raw/model-output/prefix1/prefix2/2420-01-01-team-model.parquet",
+            "s3://bucket123/raw/model-output/prefix1/prefix2/2420-01-01-team-model.parquet",
+            "s3://bucket123/model-output/prefix1/prefix2",
         ),
         (
-            'raw/prefix1/prefix2/prefix3/prefix4/2420-01-01-team-model.csv',
-            's3://bucket123/raw/prefix1/prefix2/prefix3/prefix4/2420-01-01-team-model.csv',
-            's3://bucket123/prefix1/prefix2/prefix3/prefix4',
+            "raw/prefix1/prefix2/prefix3/prefix4/2420-01-01-team-model.csv",
+            "s3://bucket123/raw/prefix1/prefix2/prefix3/prefix4/2420-01-01-team-model.csv",
+            "s3://bucket123/prefix1/prefix2/prefix3/prefix4",
         ),
-        ('raw/2420-01-01-team-model.csv', 's3://bucket123/raw/2420-01-01-team-model.csv', 's3://bucket123/.'),
+        ("raw/2420-01-01-team-model.csv", "s3://bucket123/raw/2420-01-01-team-model.csv", "s3://bucket123/."),
     ],
 )
 def test_from_s3(mocker, s3_key, expected_input_uri, expected_output_uri):
-    mocker.patch('hubverse_transform.model_output.ModelOutputHandler.__init__', return_value=None)
-    mo = ModelOutputHandler.from_s3('bucket123', s3_key)
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler.__init__", return_value=None)
+    mo = ModelOutputHandler.from_s3("bucket123", s3_key)
     mo.__init__.assert_called_once_with(expected_input_uri, expected_output_uri)
 
 
 def test_from_s3_alternate_origin_prefix(mocker):
-    mocker.patch('hubverse_transform.model_output.ModelOutputHandler.__init__', return_value=None)
+    mocker.patch("hubverse_transform.model_output.ModelOutputHandler.__init__", return_value=None)
     mo = ModelOutputHandler.from_s3(
-        'bucket123',
-        'different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.parquet',
-        origin_prefix='different-raw-prefix',
+        "bucket123",
+        "different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.parquet",
+        origin_prefix="different-raw-prefix",
     )
     mo.__init__.assert_called_once_with(
-        's3://bucket123/different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.parquet',
-        's3://bucket123/prefix1/prefix2',
+        "s3://bucket123/different-raw-prefix/prefix1/prefix2/2420-01-01-team-model.parquet",
+        "s3://bucket123/prefix1/prefix2",
     )
 
 
 def test_from_s3_missing_prefix():
     with pytest.raises(ValueError):
-        ModelOutputHandler.from_s3('test-bucket', 'prefix1/2420-01-01-team_name-model.csv')
+        ModelOutputHandler.from_s3("test-bucket", "prefix1/2420-01-01-team_name-model.csv")
 
 
 @pytest.mark.parametrize(
-    'file_uri, expected_error',
+    "file_uri, expected_error",
     [
-        ('mock:raw/prefix1/prefix2/2420-01-01-team-name-voyager1.csv', ValueError),
-        ('mock:raw/prefix1/prefix2/round_id-team-model.csv', ValueError),
-        ('mock:raw/prefix1/prefix2/2420-01-01-team-model-name.csv', ValueError),
+        ("mock:raw/prefix1/prefix2/2420-01-01-team-name-voyager1.csv", ValueError),
+        ("mock:raw/prefix1/prefix2/round_id-team-model.csv", ValueError),
+        ("mock:raw/prefix1/prefix2/2420-01-01-team-model-name.csv", ValueError),
     ],
 )
 def test_parse_s3_key_invalid_format(file_uri, expected_error):
     # ensure ValueError is raised for invalid model-output file name format
     with pytest.raises(ValueError):
-        ModelOutputHandler(file_uri, 'mock:fake-output-uri')
+        ModelOutputHandler(file_uri, "mock:fake-output-uri")
 
 
 def test_parse_input_file_invalid_type():
-    input_uri = 'mock:raw/prefix1/prefix2/2000-01-01-team1-model1.jpg'
+    input_uri = "mock:raw/prefix1/prefix2/2000-01-01-team1-model1.jpg"
 
     with pytest.raises(NotImplementedError):
-        ModelOutputHandler(input_uri, 'mock:fake-output-uri')
+        ModelOutputHandler(input_uri, "mock:fake-output-uri")
 
 
 def test_add_columns(model_output_table):
-    file_uri = 'mock:raw/prefix1/prefix2/2420-01-01-team-model.csv'
-    mo = ModelOutputHandler(file_uri, 'mock:fake-output-uri')
+    file_uri = "mock:raw/prefix1/prefix2/2420-01-01-team-model.csv"
+    mo = ModelOutputHandler(file_uri, "mock:fake-output-uri")
 
     result = mo.add_columns(model_output_table)
 
     # transformed data should have 3 new columns: round_id, team, and model
     assert result.num_columns == 5
-    assert set(['round_id', 'team_abbr', 'model_abbr']).issubset(result.column_names)
+    assert set(["round_id", "team_abbr", "model_abbr"]).issubset(result.column_names)
 
 
 def test_added_column_values(model_output_table):
-    file_uri = 'mock:raw/prefix1/prefix2/2420-01-01-janewaysaddiction-voyager1.csv'
-    mo = ModelOutputHandler(file_uri, 'mock:fake-output-uri')
+    file_uri = "mock:raw/prefix1/prefix2/2420-01-01-janewaysaddiction-voyager1.csv"
+    mo = ModelOutputHandler(file_uri, "mock:fake-output-uri")
 
     result = mo.add_columns(model_output_table)
 
     # round_id, team, and model columns should each contain a single value
     # that matches round, team, and model as derived from the file name
-    assert len(result.column('round_id').unique()) == 1
-    result.column('team_abbr').unique()[0].as_py() == '2420-01-01'
+    assert len(result.column("round_id").unique()) == 1
+    result.column("team_abbr").unique()[0].as_py() == "2420-01-01"
 
-    assert len(result.column('team_abbr').unique()) == 1
-    result.column('team_abbr').unique()[0].as_py() == 'janewaysaddiction'
+    assert len(result.column("team_abbr").unique()) == 1
+    result.column("team_abbr").unique()[0].as_py() == "janewaysaddiction"
 
-    assert len(result.column('model_abbr').unique()) == 1
-    result.column('team_abbr').unique()[0].as_py() == 'voyager1'
+    assert len(result.column("model_abbr").unique()) == 1
+    result.column("team_abbr").unique()[0].as_py() == "voyager1"
 
 
 def test_read_file_csv(test_csv_file, model_output_table):
-    mo = ModelOutputHandler(test_csv_file, 'mock:fake-output-uri')
+    mo = ModelOutputHandler(test_csv_file, "mock:fake-output-uri")
     pyarrow_table = mo.read_file()
     assert len(pyarrow_table) == 4
 
     # empty output_type_id should transform to null
-    output_type_id_col = pyarrow_table.column('output_type_id')
-    assert str(output_type_id_col[0]) == '0.5'
+    output_type_id_col = pyarrow_table.column("output_type_id")
+    assert str(output_type_id_col[0]) == "0.5"
     assert pa.compute.is_null(output_type_id_col[2]).as_py() is True
-    assert str(output_type_id_col[3]) == 'large_increase'
+    assert str(output_type_id_col[3]) == "large_increase"
 
 
 def test_read_file_parquet(test_parquet_file, model_output_table):
-    mo = ModelOutputHandler(test_parquet_file, 'mock:fake-output-uri')
+    mo = ModelOutputHandler(test_parquet_file, "mock:fake-output-uri")
     pyarrow_table = mo.read_file()
     assert len(pyarrow_table) == 4
 
     # output_type_id should retain the value from the .csv file, even when the value is empty or "NA"
-    output_type_id_col = pyarrow_table.column('output_type_id')
-    assert str(output_type_id_col[0]) == '0.5'
-    assert str(output_type_id_col[2]) == ''
-    assert str(output_type_id_col[3]) == 'large_increase'
+    output_type_id_col = pyarrow_table.column("output_type_id")
+    assert str(output_type_id_col[0]) == "0.5"
+    assert str(output_type_id_col[2]) == ""
+    assert str(output_type_id_col[3]) == "large_increase"
 
 
 def test_write_parquet(tmpdir, model_output_table):
-    output_dir = str(tmpdir.mkdir('model-output'))
+    output_dir = str(tmpdir.mkdir("model-output"))
 
-    mo = ModelOutputHandler('mock:raw/prefix1/prefix2/2420-01-01-team-model.csv', output_dir)
+    mo = ModelOutputHandler("mock:raw/prefix1/prefix2/2420-01-01-team-model.csv", output_dir)
 
-    expected_output_file_path = str(Path(*[output_dir, f'{mo.file_name}.parquet']))
+    expected_output_file_path = str(Path(*[output_dir, f"{mo.file_name}.parquet"]))
     actual_output_file_path = mo.write_parquet(model_output_table)
 
     assert actual_output_file_path == expected_output_file_path
 
 
 def test_transform_model_output_path(test_csv_file, tmpdir):
-    output_dir = str(tmpdir.mkdir('model-output'))
+    output_dir = str(tmpdir.mkdir("model-output"))
     mo = ModelOutputHandler(test_csv_file, output_dir)
     output_uri = mo.transform_model_output()
 
     input_path = Path(test_csv_file)
     output_path = Path(output_uri)
 
-    assert output_path.suffix == '.parquet'
-    assert 'raw' not in output_path.parts
+    assert output_path.suffix == ".parquet"
+    assert "raw" not in output_path.parts
     assert input_path.stem in output_path.stem


### PR DESCRIPTION
These changes are almost entirely created by the robots:

* I (a human) removed the `coverage` dependency from `pyproject.toml` (which in turn updated the lockfile: pdm.lock)
* I removed the "single quote" parameter from ruff (our code formatting tool), which then automatically updated everything to double quotes (for better style alignment with the rest of the Hubverse).