### PR TITLE
Add lambda support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,17 @@ The `pdm add` command will install the package, add it to [`pyproject.toml`](pyp
 
 Refer to [PDM's documentation](https://pdm-project.org/latest/usage/dependency/) for complete information about adding dependencies.
 
+
+## Creating and deploying the AWS Lambda package
+
+**Temporary: next step is to deploy updates to the lambda package via GitHub Actions**
+
+To package the hubverse_transform code for deployment to the `hubverse-transform-model-output` AWS Lambda function:
+
+1. Make sure you have the AWS CLI installed
+2. Make sure PDM is installed (see the dev setup instructions above)
+3. Make sure you have AWS credentials that allow writes to the `hubverse-assets` S3 bucket
+4. From the root of this project, run the deploy script:
+```bash
+source deploy_lambda.sh
+```

--- a/deploy_lambda.sh
+++ b/deploy_lambda.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# allow pip installs outside of a virtual environment
+export PIP_REQUIRE_VIRTUALENV=false
+
+build_dir="build"
+
+# create build directory if it doesn't exist, and remove any prior
+# artifacts
+echo "Removing old build artifacts"
+rm -rf $build_dir
+mkdir -p $build_dir/hubverse_transform
+
+# output project requirements
+pdm export --without dev --format requirements > $build_dir/requirements.txt
+
+# install the hubverse_transform dependencies into the build directory
+echo "Installing dependencies into the build directory"
+pip install \
+--platform manylinux2014_x86_64 \
+--target=$build_dir \
+--python-version 3.12 \
+--only-binary=:all: --upgrade \
+-r $build_dir/requirements.txt
+
+# copy the hubverse_transform package into the build directory so it
+# will be included in the lambda deployment package
+cp -r src/hubverse_transform/ $build_dir/hubverse_transform
+
+# create the zip file that will be deployed to AWS Lambda
+# https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html#gettingstarted-package-zip
+echo "Creating AWS Lambda deployment package"
+
+# step 1: zip the files in the build directory (from the above pip install, but exclude the stuff we don't need)
+echo "Zipping project dependencies"
+cd $build_dir
+py_exclude=("*.pyc" "*.ipynb" "*__pycache__*" "*ipynb_checkpoints*" "requirements.txt" "*.egg-info")
+zip -r hubverse-transform-model-output.zip . -x "${py_exclude[@]}"
+
+# step 2: add the lambda handler the .zip package
+echo "Adding lambda handler to the deployment .zip package"
+cd ..
+zip -j $build_dir/hubverse-transform-model-output.zip faas/lambda_function.py
+
+# for reference: the S3 bucket in the comment below is where our IaC (i.e., hubverse-infrastructure repo)
+# creates the placeholder lambda function for model-output-transforms
+# s3://hubverse-assets/lambda/hubverse-transform-model-output.zip
+echo "Uploading deployment package to S3 and performing aws lambda update-function-code"
+aws s3 cp build/hubverse-transform-model-output.zip s3://hubverse-assets/lambda/
+aws lambda update-function-code \
+  --function-name arn:aws:lambda:us-east-1:767397675902:function:hubverse-transform-model-output \
+  --s3-bucket hubverse-assets \
+  --s3-key lambda/hubverse-transform-model-output.zip > $build_dir/lambda_update.log
+
+echo "Lambda function updated (see $build_dir/lambda_update.log for details)"

--- a/faas/lambda_function.py
+++ b/faas/lambda_function.py
@@ -21,7 +21,9 @@ logger.setLevel("INFO")
 def lambda_handler(event, context):
     logger.info("Received event: " + json.dumps(event, indent=2))
 
-    # Get the object from the event and show its content type
+    # info from the S3 event
+    event_source = event["Records"][0]["eventSource"]
+    event_name = event["Records"][0]["eventName"]
     bucket = event["Records"][0]["s3"]["bucket"]["name"]
     key = urllib.parse.unquote_plus(event["Records"][0]["s3"]["object"]["key"], encoding="utf-8")
 
@@ -33,6 +35,12 @@ def lambda_handler(event, context):
     # if not any(ext in key.lower() for ext in extensions):
     #     print(f"{key} is not a supported file type, skipping")
     #     return
+
+    # Until we implement ModelOutputHandler functionality to act on deleted model-output files, ignore any ObjectDelete
+    # events that are triggered by by a hub's S3 bucket.
+    if "objectcreated" not in event_name.lower():
+        logger.info(f"Event type {event_source}:{event_name} is not supported, skipping")
+        return
 
     logger.info("Transforming file: {}/{}".format(bucket, key))
     try:

--- a/faas/lambda_function.py
+++ b/faas/lambda_function.py
@@ -1,0 +1,43 @@
+"""
+This the handler invoked by the Lambda function that runs whenever there's a change to a hub's uploaded model-output files.
+For the Hubverse AWS account, the baseline "hubverse-transform-model-output" Lambda is defined via our IaC (Infrastructure as Code)
+repository: hubverse-transform-model-output.
+
+This handler, along with the actual transformation module (hubverse_transform), live outside of the Hubverse's IaC repository:
+
+- To avoid tightly coupling AWS infrastructure to the more general hubverse_transform module that can be used for hubs hosted elsewhere
+- To allow faster iteration and testing of the hubverse_transform module without needing to update the IaC repo or redeploy AWS resources
+"""
+import json
+import logging
+import urllib.parse
+
+from hubverse_transform.model_output import ModelOutputHandler
+
+logger = logging.getLogger()
+logger.setLevel("INFO")
+
+
+def lambda_handler(event, context):
+    logger.info("Received event: " + json.dumps(event, indent=2))
+
+    # Get the object from the event and show its content type
+    bucket = event["Records"][0]["s3"]["bucket"]["name"]
+    key = urllib.parse.unquote_plus(event["Records"][0]["s3"]["object"]["key"], encoding="utf-8")
+
+    # Below is some old testing code that we were using to ignore all file
+    # types that don't have a supported extension. It's commented-out now, to ensure
+    # that we don't have to update this handler every time we add support for a  new
+    # file type in the model-output transforms.
+    # extensions = [".csv", ".parquet"]
+    # if not any(ext in key.lower() for ext in extensions):
+    #     print(f"{key} is not a supported file type, skipping")
+    #     return
+
+    logger.info("Transforming file: {}/{}".format(bucket, key))
+    try:
+        mo = ModelOutputHandler.from_s3(bucket, key)
+        mo.transform_model_output()
+    except Exception as e:
+        logger.exception("Error transforming file: {}/{}".format(key, bucket))
+        raise e

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,40 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:fd9ab7ed4ba72966f75461da953ff982e35705dacb652d5f56b41ed3693d6cab"
-
-[[package]]
-name = "boto3"
-version = "1.34.81"
-requires_python = ">=3.8"
-summary = "The AWS SDK for Python"
-groups = ["default"]
-dependencies = [
-    "botocore<1.35.0,>=1.34.81",
-    "jmespath<2.0.0,>=0.7.1",
-    "s3transfer<0.11.0,>=0.10.0",
-]
-files = [
-    {file = "boto3-1.34.81-py3-none-any.whl", hash = "sha256:18224d206a8a775bcaa562d22ed3d07854934699190e12b52fcde87aac76a80e"},
-    {file = "boto3-1.34.81.tar.gz", hash = "sha256:004dad209d37b3d2df88f41da13b7ad702a751904a335fac095897ff7a19f82b"},
-]
-
-[[package]]
-name = "botocore"
-version = "1.34.81"
-requires_python = ">=3.8"
-summary = "Low-level, data-driven core of boto 3."
-groups = ["default"]
-dependencies = [
-    "jmespath<2.0.0,>=0.7.1",
-    "python-dateutil<3.0.0,>=2.1",
-    "urllib3!=2.2.0,<3,>=1.25.4; python_version >= \"3.10\"",
-    "urllib3<1.27,>=1.25.4; python_version < \"3.10\"",
-]
-files = [
-    {file = "botocore-1.34.81-py3-none-any.whl", hash = "sha256:85f6fd7c5715eeef7a236c50947de00f57d72e7439daed1125491014b70fab01"},
-    {file = "botocore-1.34.81.tar.gz", hash = "sha256:f79bf122566cc1f09d71cc9ac9fcf52d47ba48b761cbc3f064017b36a3c40eb8"},
-]
+content_hash = "sha256:04f9150ceadab68b2b0fb6fafd45070db78eb18654e2ec88e9292adf2d1b833f"
 
 [[package]]
 name = "colorama"
@@ -73,17 +40,6 @@ groups = ["dev"]
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
-]
-
-[[package]]
-name = "jmespath"
-version = "1.0.1"
-requires_python = ">=3.7"
-summary = "JSON Matching Expressions"
-groups = ["default"]
-files = [
-    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
-    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
 
 [[package]]
@@ -236,20 +192,6 @@ files = [
 ]
 
 [[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-summary = "Extensions to the standard Python datetime module"
-groups = ["default"]
-dependencies = [
-    "six>=1.5",
-]
-files = [
-    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
-    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
-]
-
-[[package]]
 name = "ruff"
 version = "0.3.5"
 requires_python = ">=3.7"
@@ -276,31 +218,6 @@ files = [
 ]
 
 [[package]]
-name = "s3transfer"
-version = "0.10.1"
-requires_python = ">= 3.8"
-summary = "An Amazon S3 Transfer Manager"
-groups = ["default"]
-dependencies = [
-    "botocore<2.0a.0,>=1.33.2",
-]
-files = [
-    {file = "s3transfer-0.10.1-py3-none-any.whl", hash = "sha256:ceb252b11bcf87080fb7850a224fb6e05c8a776bab8f2b64b7f25b969464839d"},
-    {file = "s3transfer-0.10.1.tar.gz", hash = "sha256:5683916b4c724f799e600f41dd9e10a9ff19871bf87623cc8f491cb4f5fa0a19"},
-]
-
-[[package]]
-name = "six"
-version = "1.16.0"
-requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-summary = "Python 2 and 3 compatibility utilities"
-groups = ["default"]
-files = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
-]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 requires_python = ">=3.7"
@@ -321,15 +238,4 @@ groups = ["dev"]
 files = [
     {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
     {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
-]
-
-[[package]]
-name = "urllib3"
-version = "1.26.18"
-requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-summary = "HTTP library with thread-safe connection pooling, file post, and more."
-groups = ["default"]
-files = [
-    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
-    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
 ]
 
 dependencies = [
-    'boto3',
     "pyarrow>=16.0.0",
 ]
 authors = [


### PR DESCRIPTION
Resolves #4 

Although the `hubverse_transform` package in this repo can be installed and run anywhere, our most immediate need is to run it as an AWS Lambda function (Lambda is AWS's function-as-a-service offering).

To get this deployed to the `hubverse-transform-model-output` Lambda that already exists in the Hubverse's AWS account*,  this PR adds two things:

1. A handler function that is invoked whenever an AWS event triggers the lambda (when a hub's bucket receives a new model-output file, for example)
2. A deployment script that packages the code into the [.zip structure required by lambda](https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-create-dependencies)

![image](https://github.com/Infectious-Disease-Modeling-Hubs/hubverse-transform/assets/540544/ae2fb531-b347-4fda-958c-a9331c51db27)
