### PR TITLE
Replace team_abbr and model_abbr output columns with model_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ output_type: string
 output_type_id: double
 value: double
 round_id: string
-team: string
-model: string
+model_id: string
 ----
 reference_date: [[2023-10-14,2023-10-14]]
 location: [["01","01"]]
@@ -83,7 +82,7 @@ output_type: [["quantile","quantile"]]
 output_type_id: [[0.01,0.025]]
 value: [[0,1.5810684371620558]]
 round_id: [["2023-10-14","2023-10-14"]]
-team: [["UMass","UMass"]]
+model_id: [["UMass-flusion","UMass-flusion"]]
 ...
 ```
 

--- a/faas/lambda_function.py
+++ b/faas/lambda_function.py
@@ -42,10 +42,10 @@ def lambda_handler(event, context):
         logger.info(f"Event type {event_source}:{event_name} is not supported, skipping")
         return
 
-    logger.info("Transforming file: {}/{}".format(bucket, key))
+    logger.info(f"Transforming file: {bucket}/{key}")
     try:
         mo = ModelOutputHandler.from_s3(bucket, key)
         mo.transform_model_output()
     except Exception as e:
-        logger.exception("Error transforming file: {}/{}".format(key, bucket))
+        logger.exception(f"Error transforming file: {bucket}/{key}")
         raise e


### PR DESCRIPTION
Resolves #2 

Given @lmullany's findings when converting the archived FluSight repo into hubverse format, we made a decision to simplify how we're parsing model-output file names.

TL;DR: instead of creating separate model and team abbr columns in the transformed parquet file, we're going to create a single `model_id` column (see the linked issue for more details).

This PR also sneaks in a minor change to logging strings based on feedback from @matthewcornell 