### PR TITLE
Replace pathlib with cloudpathlib

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,70 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:04f9150ceadab68b2b0fb6fafd45070db78eb18654e2ec88e9292adf2d1b833f"
+content_hash = "sha256:bfacee54a53dc2a7ddeb3c4e24cb2b45cdc6826198f514f9245d40a4fe1ebbf0"
+
+[[package]]
+name = "boto3"
+version = "1.34.105"
+requires_python = ">=3.8"
+summary = "The AWS SDK for Python"
+groups = ["default"]
+dependencies = [
+    "botocore<1.35.0,>=1.34.105",
+    "jmespath<2.0.0,>=0.7.1",
+    "s3transfer<0.11.0,>=0.10.0",
+]
+files = [
+    {file = "boto3-1.34.105-py3-none-any.whl", hash = "sha256:b633e8fbf7145bdb995ce68a27d096bb89fd393185b0e773418d81cd78db5a03"},
+    {file = "boto3-1.34.105.tar.gz", hash = "sha256:f2c11635be0de7b7c06eb606ece1add125e02d6ed521592294a0a21af09af135"},
+]
+
+[[package]]
+name = "botocore"
+version = "1.34.105"
+requires_python = ">=3.8"
+summary = "Low-level, data-driven core of boto 3."
+groups = ["default"]
+dependencies = [
+    "jmespath<2.0.0,>=0.7.1",
+    "python-dateutil<3.0.0,>=2.1",
+    "urllib3!=2.2.0,<3,>=1.25.4; python_version >= \"3.10\"",
+    "urllib3<1.27,>=1.25.4; python_version < \"3.10\"",
+]
+files = [
+    {file = "botocore-1.34.105-py3-none-any.whl", hash = "sha256:a459d060b541beecb50681e6e8a39313cca981e146a59ba7c5229d62f631a016"},
+    {file = "botocore-1.34.105.tar.gz", hash = "sha256:727d5d3e800ac8b705fca6e19b6fefa1e728a81d62a712df9bd32ed0117c740b"},
+]
+
+[[package]]
+name = "cloudpathlib"
+version = "0.18.1"
+requires_python = ">=3.7"
+summary = "pathlib-style classes for cloud storage services."
+groups = ["default"]
+dependencies = [
+    "typing-extensions>4; python_version < \"3.11\"",
+]
+files = [
+    {file = "cloudpathlib-0.18.1-py3-none-any.whl", hash = "sha256:20efd5d772c75df91bb2ac52e053be53fd9000f5e9755fd92375a2a9fe6005e0"},
+    {file = "cloudpathlib-0.18.1.tar.gz", hash = "sha256:ffd22f324bfbf9c3f2bc1bec6e8372cb372a0feef17c7f2b48030cd6810ea859"},
+]
+
+[[package]]
+name = "cloudpathlib"
+version = "0.18.1"
+extras = ["s3"]
+requires_python = ">=3.7"
+summary = "pathlib-style classes for cloud storage services."
+groups = ["default"]
+dependencies = [
+    "boto3",
+    "cloudpathlib==0.18.1",
+]
+files = [
+    {file = "cloudpathlib-0.18.1-py3-none-any.whl", hash = "sha256:20efd5d772c75df91bb2ac52e053be53fd9000f5e9755fd92375a2a9fe6005e0"},
+    {file = "cloudpathlib-0.18.1.tar.gz", hash = "sha256:ffd22f324bfbf9c3f2bc1bec6e8372cb372a0feef17c7f2b48030cd6810ea859"},
+]
 
 [[package]]
 name = "colorama"
@@ -40,6 +103,17 @@ groups = ["dev"]
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+requires_python = ">=3.7"
+summary = "JSON Matching Expressions"
+groups = ["default"]
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
 
 [[package]]
@@ -192,6 +266,20 @@ files = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+summary = "Extensions to the standard Python datetime module"
+groups = ["default"]
+dependencies = [
+    "six>=1.5",
+]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[[package]]
 name = "ruff"
 version = "0.3.5"
 requires_python = ">=3.7"
@@ -218,6 +306,31 @@ files = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.10.1"
+requires_python = ">= 3.8"
+summary = "An Amazon S3 Transfer Manager"
+groups = ["default"]
+dependencies = [
+    "botocore<2.0a.0,>=1.33.2",
+]
+files = [
+    {file = "s3transfer-0.10.1-py3-none-any.whl", hash = "sha256:ceb252b11bcf87080fb7850a224fb6e05c8a776bab8f2b64b7f25b969464839d"},
+    {file = "s3transfer-0.10.1.tar.gz", hash = "sha256:5683916b4c724f799e600f41dd9e10a9ff19871bf87623cc8f491cb4f5fa0a19"},
+]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+summary = "Python 2 and 3 compatibility utilities"
+groups = ["default"]
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 requires_python = ">=3.7"
@@ -234,8 +347,19 @@ name = "typing-extensions"
 version = "4.11.0"
 requires_python = ">=3.8"
 summary = "Backported and Experimental Type Hints for Python 3.8+"
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
     {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
+]
+
+[[package]]
+name = "urllib3"
+version = "1.26.18"
+requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+summary = "HTTP library with thread-safe connection pooling, file post, and more."
+groups = ["default"]
+files = [
+    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
+    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
 
 dependencies = [
     "pyarrow>=16.0.0",
+    "cloudpathlib[s3]>=0.18.1",
 ]
 authors = [
     {name = "Becky Sweger", email = "rsweger@umass.edu"},

--- a/src/hubverse_transform/model_output.py
+++ b/src/hubverse_transform/model_output.py
@@ -1,10 +1,10 @@
 import logging
-import pathlib
 import re
 from urllib.parse import quote
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+from cloudpathlib import AnyPath
 from pyarrow import csv, fs
 
 # Log to stdout
@@ -27,7 +27,7 @@ class ModelOutputHandler:
         self.output_path = output_filesystem[1]
 
         # get file name and type from input file
-        path = pathlib.Path(self.input_file)
+        path = AnyPath(self.input_file)
         self.file_name = path.stem
         self.file_type = path.suffix
 
@@ -55,7 +55,7 @@ class ModelOutputHandler:
         # data (i.e., as submitted my modelers). This check ensures that the file being
         # transformed has originated from wherever a hub keeps these "raw" (un-altered)
         # model-outputs.
-        path = pathlib.Path(s3_key)
+        path = AnyPath(s3_key)
         if path.parts[0] != origin_prefix:
             raise ValueError(f"Model output path {s3_key} does not begin with {origin_prefix}.")
 
@@ -70,11 +70,11 @@ class ModelOutputHandler:
     def sanitize_uri(self, uri: str, safe=":/") -> str:
         """Sanitize URIs for use with pyarrow's filesystem."""
 
-        uri_path = pathlib.Path(uri)
+        uri_path = AnyPath(uri)
 
         # remove spaces at the end of a filename (e.g., my-model-output .csv) and
         # also at the beginning and end of the path string
-        clean_path = pathlib.Path(str(uri_path).replace(uri_path.stem, uri_path.stem.strip()))
+        clean_path = AnyPath(str(uri_path).replace(uri_path.stem, uri_path.stem.strip()))
         clean_string = str(clean_path).strip()
 
         # encode the cleaned path (for example, any remaining spaces) so we can

--- a/test/unit/test_model_output.py
+++ b/test/unit/test_model_output.py
@@ -106,6 +106,22 @@ def test_new_instance():
 
 
 @pytest.mark.parametrize(
+    "original_uri, expected_sanitized_uri",
+    [
+        ("s3://hub-bucket/raw/round name/model name.parquet", "s3://hub-bucket/raw/round%20name/model%20name.parquet"),
+        ("mock:hub-bucket/raw/round name/model name.parquet", "mock:hub-bucket/raw/round%20name/model%20name.parquet"),
+        ("/tmp/bucket 1/a local file.csv", "/tmp/bucket%201/a%20local%20file.csv"),
+    ],
+)
+def test_sanitize_uri(original_uri, expected_sanitized_uri):
+    # instantiate a ModelOutputHandler object with uris we don't care about (as a way to
+    # test the sanitize_uri method against various types of URIs supported by the pyarrow filesystem
+    mo = ModelOutputHandler("mock:/input-uri/2024-01-01 file.parquet", "mock:/output-uri")
+
+    assert mo.sanitize_uri(original_uri) == expected_sanitized_uri
+
+
+@pytest.mark.parametrize(
     "file_uri, expected_round_id, expected_model_id",
     [
         ("mock:raw/prefix/2420-01-01-team-model.csv", "2420-01-01", "team-model"),


### PR DESCRIPTION
This handles an error caused by treating S3 URIs like a regular path. 

Instead, we can use cloudpathlib, which acts like Python's built-in pathlib but recognizes the URI formats of various cloud providers.