### PR TITLE
Throw warnings when the incoming file is not valid

### DIFF
--- a/faas/lambda_function.py
+++ b/faas/lambda_function.py
@@ -46,6 +46,8 @@ def lambda_handler(event, context):
     try:
         mo = ModelOutputHandler.from_s3(bucket, key)
         mo.transform_model_output()
+    except UserWarning:
+        pass
     except Exception as e:
         logger.exception(f"Error transforming file: {bucket}/{key}")
         raise e

--- a/src/hubverse_transform/model_output.py
+++ b/src/hubverse_transform/model_output.py
@@ -26,8 +26,6 @@ class ModelOutputHandler:
         self.fs_output = output_filesystem[0]
         self.output_path = output_filesystem[1]
 
-        self.valid_file = True
-
         # get file name and type from input file
         path = AnyPath(self.input_file)
         self.file_name = path.stem

--- a/test/unit/test_model_output.py
+++ b/test/unit/test_model_output.py
@@ -244,13 +244,6 @@ def test_parse_s3_key_invalid_format(file_uri, expected_error):
         ModelOutputHandler(file_uri, "mock:fake-output-uri")
 
 
-def test_parse_input_file_invalid_type():
-    input_uri = "mock:raw/prefix1/prefix2/2000-01-01-team1-model1.jpg"
-
-    with pytest.raises(NotImplementedError):
-        ModelOutputHandler(input_uri, "mock:fake-output-uri")
-
-
 def test_add_columns(model_output_table):
     file_uri = "mock:raw/prefix1/prefix2/2420-01-01-team-model.csv"
     mo = ModelOutputHandler(file_uri, "mock:fake-output-uri")
@@ -323,3 +316,18 @@ def test_transform_model_output_path(test_csv_file, tmpdir):
     assert output_path.suffix == ".parquet"
     assert "raw" not in output_path.parts
     assert input_path.stem in output_path.stem
+
+
+@pytest.mark.parametrize(
+    "file_uri",
+    [
+        ("mock:raw/prefix1/prefix2/"),
+        ("mock:raw/prefix1/prefix2/round_id-team-model.txt"),
+        ("mock:photo.jpg"),
+        ("mock:raw/prefix1/prefix2/01-02-2440-team-model-name"),
+    ],
+)
+def test_invalid_file_warning(file_uri):
+    # ensure ValueError is raised for invalid model-output file name format
+    with pytest.raises(UserWarning):
+        ModelOutputHandler(file_uri, "mock:fake-output-uri")


### PR DESCRIPTION
We've recently encountered two situations when testing the transform lambdas that should not raise errors:

1. someone manually creates a folder in a hub's raw/ S3 folder, which triggers an S3 creation event
2. model-output folders contain an .md or .txt file that should not be included in the transform process

Raising a `UserWarning` allows the invoking process (in our case, the lambda handler) to handle these scenarios as they see fit. 